### PR TITLE
Fix base referencing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+### Version 0.1.0.9016
+
+* Explicitly use `base::` in `column_transformation` to avoid crazy
+  scenarios where a global function exists with the same name (because
+  not everyone knows what's in base).
+
 ### Version 0.1.0.9015
 
 * Ensure that names are preserved for legacy mungebits too.
+
 ### Version 0.1.0.9014
 
 * Ensure that names are preserved when munging using `munge`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: A way of thinking about data preparation that
     online prediction so that both can be described by the same codebase.
     With mungebits, you can save time on having to re-implement your
     R code to work in production and instead re-use the same codebase.
-Version: 0.1.0.9015
+Version: 0.1.0.9016
 Author: Robert Krzyzanowski <rob@syberia.io>
 Maintainer: Robert Krzyzanowski <rob@syberia.io>
 Authors@R: c(person("Robert", "Krzyzanowski",


### PR DESCRIPTION
@abelcastilloavant @peterhurford @kirillseva This little snaggler came up when I had a global variable `match <- function(...) { foo }`, since it gets used in the body, which passes through `globalenv()` when searching parent environments.

I think this may be too slow for column transformation, however, given that under the hood we are calling

```r
`::`(quote(base), quote(foo))
```

repeatedly. Potentially a better alternative is to do the silly thing and copy those aliases `match <- base::match` into the package and shadow them directly for a boost. I'll do some benchmarks tomorrow.