### PR TITLE
Update to Travis-CI R

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
-language: c
-dist: trusty
-before_install:
-- curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-- chmod 755 ./travis-tool.sh
-- "./travis-tool.sh bootstrap"
-install:
-- "./travis-tool.sh install_github syberia/stagerunner robertzk/mungebits robertzk/testthatsomemore kirillseva/covr"
-- "./travis-tool.sh install_deps"
-- "./travis-tool.sh install_r testthat microbenchmark"
-script: "./travis-tool.sh run_tests"
-after_failure:
-- "./travis-tool.sh dump_logs"
+language: r
+cache: packages
+r_github_packages:
+    - syberia/stagerunner
+    - robertzk/testthatsomemore
+    - kirillseva/covr
+    - robertzk/mungebits
+
+r_binary_packages:
+    - testthat
+    - microbenchmark
+    - crayon
+    - httr
+    - jsonlite
+    - whisker
+    - shiny
+    - devtools
+
 after_success:
   - "Rscript -e 'library(covr);coveralls()'"
+
 notifications:
   webhooks:
     urls:
@@ -28,7 +34,6 @@ notifications:
     template:
     - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}
       | Details: %{build_url} | Changes: %{compare_url}"
-sudo: true 
 env:
   - global:
     - WARNINGS_ARE_ERRORS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ r_github_packages:
     - robertzk/mungebits
 
 r_binary_packages:
+    - roxygen2
     - testthat
     - microbenchmark
     - crayon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: r
-sudo: true
+sudo: required
 cache: packages
 r_github_packages:
     - syberia/stagerunner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: r
+sudo: true
 cache: packages
 r_github_packages:
     - syberia/stagerunner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: r
 sudo: required
 cache: packages
+dist: trusty
 r_github_packages:
     - syberia/stagerunner
     - robertzk/testthatsomemore

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: r
 sudo: required
 cache: packages
 dist: trusty
+r:
+    - oldrel
+    - release
+    - devel
 r_github_packages:
     - syberia/stagerunner
     - robertzk/testthatsomemore


### PR DESCRIPTION
By updating to https://docs.travis-ci.com/user/languages/r, which supports the installation of binary R packages from https://launchpad.net/~marutter/+archive/ubuntu/c2d4u, we can potentially speed up testing and build time.